### PR TITLE
Render template content before rendering layout content

### DIFF
--- a/lib/rodakase/view/layout.rb
+++ b/lib/rodakase/view/layout.rb
@@ -58,8 +58,10 @@ module Rodakase
       def call(options = {})
         renderer = self.class.renderer(options.fetch(:format, default_format))
 
+        template_content = renderer.(template_path, template_scope(options, renderer))
+
         renderer.(layout_path, layout_scope(options, renderer)) do
-          renderer.(template_path, template_scope(options, renderer))
+          template_content
         end
       end
 


### PR DESCRIPTION
This is a slight procedural change that will allow things like sharing content from the template up to the layout. For example if a "content_for"-style method was made available to both the template and the layouts, then it would be important to render the template first so that it could provide the "content_for" data, which would then be used by the layout (e.g. useful for specifying page-specific content that needs to go into the layout’s `<head>`).