### PR TITLE
Use a part object as the layout template's scope

### DIFF
--- a/lib/rodakase/view/layout.rb
+++ b/lib/rodakase/view/layout.rb
@@ -11,8 +11,6 @@ module Rodakase
     class Layout
       include Dry::Equalizer(:config)
 
-      Scope = Struct.new(:page)
-
       DEFAULT_DIR = 'layouts'.freeze
 
       extend Dry::Configurable
@@ -93,7 +91,11 @@ module Rodakase
       private
 
       def layout_scope(options, renderer)
-        Scope.new(layout_part(:page, renderer, options.fetch(:scope, scope)))
+        part_hash = {
+          page: layout_part(:page, renderer, options.fetch(:scope, scope))
+        }
+
+        part(layout_dir, renderer, part_hash)
       end
 
       def template_scope(options, renderer)


### PR DESCRIPTION
Instead of using a struct with a `page` accessor as the layout's scope, use a Rodakase::View::Part` object like we already do for the non-layout templates.

This allows rendering of partials via `== partial_name` instead of having to chain them onto the page object (i.e. `== page.partial_name`).

The general upshot is that it makes authoring layouts much more consistent with authoring templates by making the same partial rendering behaviour apply everywhere.