### PR TITLE
Include the “page” scope object in the parts provided to templates

### DIFF
--- a/lib/rodakase/view/layout.rb
+++ b/lib/rodakase/view/layout.rb
@@ -97,7 +97,9 @@ module Rodakase
       end
 
       def template_scope(options, renderer)
-        parts(locals(options), renderer)
+        locals = locals(options).merge(page: options.fetch(:scope, scope))
+
+        parts(locals, renderer)
       end
 
       def layout_part(name, renderer, value)


### PR DESCRIPTION
This is the last of my 3 little view tweaks today :) And perhaps the most controversial!

I hinted in #18 about how a "content_for"-stye method on the page object could be used to share content up to the layout from within a view's template. We have this in place using this patch on one of our rodakase apps, and it looks a bit like this. Inside a template file:

```slim
== page.content_for :head do
  meta name="citation_title" content=article.title
  - contributors.each do |contributor|
    meta name="citation_author" content=contributor.display_name
```

And inside the layout:

```slim
== page.content_for :head
```

As you can probably guess, this depends on both #18 and this PR here, which exposes `page` to all templates as well as layout (otherwise there's no common object to store that "content_for" data).

As well as this, having `page` accessible everywhere allows templates to access common, site-wide functionality, like, for example, having access to an `page.assets` object of some kind, which would allows templates to get the URLs of assets, whether loaded on-the-fly in development, or precompiled in production.

I know we've had some chats about exploring alternative ways to doing this, and I'd be happy to talk further and to spearhead some other explorations, but in the meantime, I think this definitely increases the utility of the Rodakase views (and I'd be happy if we worked with this `page` object knowing it will likely go away and be replaced by something different in the future).