### PR TITLE
[WIP] Add app-wide config

### DIFF
--- a/dry-web.gemspec
+++ b/dry-web.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "dry-component", "~> 0"
+  spec.add_runtime_dependency "dry-validation"
+  spec.add_runtime_dependency "thread_safe"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 11.0"

--- a/lib/dry/web/config.rb
+++ b/lib/dry/web/config.rb
@@ -1,0 +1,38 @@
+require "yaml"
+require "thread_safe" # FIXME why does dry-validation need me to require this?
+require "dry-validation"
+require "dry/web/config/struct"
+
+module Dry
+  module Web
+    class Config
+      ConfigNotValidException = Class.new(StandardError)
+
+      attr_reader :schema
+
+      def initialize(&block)
+        @schema = Dry::Validation.Form(&block)
+      end
+
+      def load(*sources)
+        validation = schema.(combine(sources))
+
+        raise ConfigNotValidException, validation.messages if validation.failure?
+
+        Struct.new(validation)
+      end
+
+      private
+
+      def combine(sources)
+        data = sources.reverse.inject({}) { |memo, source|
+          memo.merge(normalize(source))
+        }
+      end
+
+      def normalize(data)
+        data.to_h.map { |k, v| [k.downcase.to_sym, v] }.to_h
+      end
+    end
+  end
+end

--- a/lib/dry/web/config/struct.rb
+++ b/lib/dry/web/config/struct.rb
@@ -1,0 +1,20 @@
+module Dry
+  module Web
+    class Config
+      class Struct
+        def initialize(data)
+          @data = data.map { |key, val|
+            val = val.kind_of?(Hash) ? self.class.new(val) : val
+            [key, val]
+          }.to_h
+
+          @data.keys.each do |key|
+            define_singleton_method(key) do
+              @data[key]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/web/container.rb
+++ b/lib/dry/web/container.rb
@@ -1,4 +1,5 @@
 require 'dry/component/container'
+require "dry/web/config"
 
 module Dry
   module Web

--- a/lib/dry/web/umbrella.rb
+++ b/lib/dry/web/umbrella.rb
@@ -1,0 +1,13 @@
+require "dry/web/config"
+
+module Dry
+  module Web
+    class Umbrella < Dry::Web::Container
+      setting :options, Object.new
+
+      def self.options
+        config.options
+      end
+    end
+  end
+end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,0 +1,100 @@
+require "dry/web/config"
+
+RSpec.describe Dry::Web::Config do
+  describe ".new" do
+    it "builds a validation schema" do
+      config = Dry::Web::Config.new do
+        key(:api_key).required
+      end
+
+      expect(config.schema).to be_a Dry::Validation::Schema
+      expect(config.schema.rules.keys).to include :api_key
+    end
+  end
+
+  describe "#load" do
+    subject(:config) { Dry::Web::Config.new(&schema).load(*sources) }
+
+    let(:schema) {->{
+      key(:api_key).required
+      key(:precompiled_assets).required(:bool?)
+      key(:assets_host).required
+    }}
+
+    let(:sources) { [source] }
+
+    let(:source) {
+      {
+        "api_key" => "abc123",
+        "precompiled_assets" => "1",
+        "assets_host" => "http://localhost:1234/",
+        "foo" => "bar"
+      }
+    }
+
+    it "sanitizes input" do
+      expect(config).not_to respond_to(:foo)
+    end
+
+    it "coerces input" do
+      expect(config.precompiled_assets).to eq true
+    end
+
+    context "invalid config" do
+      let(:schema) {->{
+        key(:maximum_fneeps).required
+      }}
+
+      it "raises an exception" do
+        expect { config }.to raise_error Dry::Web::Config::ConfigNotValidException
+      end
+    end
+
+    describe "using multiple sources (e.g. YAML file and ENV)" do
+      let(:sources) { [source, env_source] }
+
+      let(:source) {
+        {"api_key" => "abc123"}
+      }
+
+      let(:env_source) {
+        {
+          "API_KEY" => "env123",
+          "PRECOMPILED_ASSETS" => "1",
+          "ASSETS_HOST" => "http://localhost:1234/provided_by_env",
+          "PATH" => "/usr/local/bin:/usr/bin",
+        }
+      }
+
+      it "prioritises keys from the YAML source" do
+        expect(config.api_key).to eq "abc123"
+      end
+
+      it "falls back to the ENV source for keys missing from the YAML source, and can find keys using conventional uppser-cased ENV vars" do
+        expect(config.assets_host).to eq "http://localhost:1234/provided_by_env"
+      end
+    end
+
+    describe "using a source that supports nesting" do
+      let(:schema) {->{
+        key(:aws).schema do
+          key(:access_key).required
+          key(:bucket_name).required
+        end
+      }}
+
+      let(:source) {
+        {
+          "aws" => {
+            "access_key" => "xyz",
+            "bucket_name" => "my-bucket",
+          }
+        }
+      }
+
+      it "supports access to nested keys" do
+        expect(config.aws.bucket_name).to eq "my-bucket"
+      end
+    end
+  end
+end


### PR DESCRIPTION
So I started working on an app config loader, but I'm not sure I like it.

You'd use put it on a container like this:

```ruby
module Berg
  class Container < Dry::Web::Umbrella
    configure do |config|
      config.name = :core
      config.auto_register = %w[lib/authentication]
    end

    # Boot the config as early as we can
    boot! :config

    load_paths! "lib"
  end
end
```

Via this `boot/config.rb` file:

```ruby
require "dry/web/config"

module Berg
  AppConfig = Dry::Web::Config.new do
    required(:admin_url).filled
    required(:admin_mailer_from_email).filled

    # other schema stuff here
  end
end

Berg::Container.finalize :config do |container|
  path = container.root.join("config/application.yml")
  yaml = File.exist?(path) ? YAML.load_file(path)[container.config.env.to_s] : {}

  container.config.options = Berg::AppConfig.load(yaml, ENV)
end
```

What I do like is that this makes the config loading much more explicit, and within the control of the app developer, rather than it being hard-coded into the dry-web gem (or anything else). This will make it easier for the app developer to make their own tweaks if they like (e.g. loading from a different file, or from ENV only, or anything like that).

I also like the idea of a dry-v doing some work here because it means we can have quite sophisticated validation of app config (e.g. things beyond single-value configs, like "setting A must be <like this> if setting B is <like that>")

*However:*

- dry-v feels like a really heavyweight dependency, and I'm not sure if we'd want to force it on people at this point so early in an app's setup.
- It's DSL doesn't feel _quite_ right for defining app config.
- And (admittedly, this may just be a bug to be fixed) having dry-v loaded this early interfered with my own i18n boot file that has to load gems in a particular order to get i18n to work properly with dry-v

It also feels like the the connection of the config to the container is really tenuous. It'd be nice if we had a more formal interface to applying config. I know the idea was to experiment with config a little at this dry-web level before looking at improving it in dry-component, but I'm already feeling like we should make it better. What do I mean by more formal? I'm not entirely sure, but perhaps a proper way to "mount" or "boot" a component with external config (like e.g. what we're loading from YAML/ENV), rather than config being this weird object just hanging off `Container.config.options`.

What I feel like components should do is _declare_ the config they want, and then pull it off whatever config object is passed to them from the outside.

And maybe related, that naming issue of having a "config" object sit at e.g. `config.options` would be nice to resolve too. We can't use `config` because dry-configurable owns it, so what can we do?

Anyway, I thought I'd throw this up if anyone wants to take a look and share any thoughts. I'll have another look at things with a fresh mind tomorrow.