### PR TITLE
App settings on a top-level “Umbrella” container

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem "dry-component"
+
 group :test do
   gem 'byebug', platform: :mri
   gem 'codeclimate-test-reporter'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "dry-component"
+gem "dry-component", github: "dry-rb/dry-component", branch: "master"
 
 group :test do
   gem 'byebug', platform: :mri

--- a/dry-web.gemspec
+++ b/dry-web.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "dry-component", "~> 0"
+  spec.add_runtime_dependency "dry-component"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 11.0"

--- a/lib/dry/web/settings.rb
+++ b/lib/dry/web/settings.rb
@@ -3,6 +3,8 @@ require "yaml"
 module Dry
   module Web
     class Settings
+      TypeError = Class.new(StandardError)
+
       AnyType = Class.new do
         def self.[](value)
           value
@@ -41,7 +43,12 @@ module Dry
 
           schema.each do |key, type|
             value = ENV.fetch(key.to_s.upcase) { yaml_data[key.to_s.downcase] }
-            value = type[value]
+
+            begin
+              value = type[value]
+            rescue => e
+              raise TypeError, "error typecasting +#{key}+: #{e}"
+            end
 
             setting key, value
           end

--- a/lib/dry/web/settings.rb
+++ b/lib/dry/web/settings.rb
@@ -1,0 +1,50 @@
+module Dry
+  module Web
+    class Settings
+      AnyType = Class.new do
+        def self.[](value)
+          value
+        end
+      end
+
+      def self.schema
+        @schema ||= {}
+      end
+
+      def self.setting(name, type = AnyType)
+        settings(name => type)
+      end
+
+      def self.settings(new_schema)
+        check_schema_duplication(new_schema)
+        @schema = schema.merge(new_schema)
+
+        self
+      end
+
+      def self.check_schema_duplication(new_schema)
+        shared_keys = new_schema.keys & schema.keys
+
+        raise ArgumentError, "Setting :#{shared_keys.first} has already been defined" if shared_keys.any?
+      end
+      private_class_method :check_schema_duplication
+
+      def self.load(root, env)
+        yaml_path = root.join("config/settings.yml")
+        yaml_data = File.exist?(yaml_path) ? YAML.load_file(yaml_path)[env.to_s] : {}
+        schema = self.schema
+
+        Class.new do
+          extend Dry::Configurable
+
+          schema.each do |key, type|
+            value = ENV.fetch(key.to_s.upcase) { yaml_data[key.to_s.downcase] }
+            value = type[value]
+
+            setting key, value
+          end
+        end.config
+      end
+    end
+  end
+end

--- a/lib/dry/web/settings.rb
+++ b/lib/dry/web/settings.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 module Dry
   module Web
     class Settings

--- a/lib/dry/web/settings.rb
+++ b/lib/dry/web/settings.rb
@@ -5,17 +5,11 @@ module Dry
     class Settings
       TypeError = Class.new(StandardError)
 
-      AnyType = Class.new do
-        def self.[](value)
-          value
-        end
-      end
-
       def self.schema
         @schema ||= {}
       end
 
-      def self.setting(name, type = AnyType)
+      def self.setting(name, type = nil)
         settings(name => type)
       end
 
@@ -45,7 +39,7 @@ module Dry
             value = ENV.fetch(key.to_s.upcase) { yaml_data[key.to_s.downcase] }
 
             begin
-              value = type[value]
+              value = type[value] if type
             rescue => e
               raise TypeError, "error typecasting +#{key}+: #{e}"
             end

--- a/lib/dry/web/settings.rb
+++ b/lib/dry/web/settings.rb
@@ -3,7 +3,7 @@ require "yaml"
 module Dry
   module Web
     class Settings
-      TypeError = Class.new(StandardError)
+      SettingValueError = Class.new(StandardError)
 
       def self.schema
         @schema ||= {}
@@ -41,7 +41,7 @@ module Dry
             begin
               value = type[value] if type
             rescue => e
-              raise TypeError, "error typecasting +#{key}+: #{e}"
+              raise SettingValueError, "error typecasting +#{key}+: #{e}"
             end
 
             setting key, value

--- a/lib/dry/web/umbrella.rb
+++ b/lib/dry/web/umbrella.rb
@@ -1,15 +1,18 @@
-require "dry/web/settings"
-
 module Dry
   module Web
     class Umbrella < Dry::Web::Container
-      setting :settings
+      EmptySettings = Class.new
+
+      setting :settings_loader
+      setting :settings, EmptySettings.new
 
       def self.configure(env = config.env, &block)
         super() do |config|
           yield(config) if block
 
-          config.settings = Settings.load(root, env) unless config.settings
+          if config.settings_loader && config.settings.kind_of?(EmptySettings)
+            config.settings = config.settings_loader.load(root, env)
+          end
         end
 
         self

--- a/lib/dry/web/umbrella.rb
+++ b/lib/dry/web/umbrella.rb
@@ -1,16 +1,14 @@
 module Dry
   module Web
     class Umbrella < Dry::Web::Container
-      EmptySettings = Class.new
-
       setting :settings_loader
-      setting :settings, EmptySettings.new
+      setting :settings
 
       def self.configure(env = config.env, &block)
         super() do |config|
           yield(config) if block
 
-          if config.settings_loader && config.settings.kind_of?(EmptySettings)
+          if config.settings_loader && config.settings.nil?
             config.settings = load_settings(config.settings_loader, root, env)
           end
         end

--- a/lib/dry/web/umbrella.rb
+++ b/lib/dry/web/umbrella.rb
@@ -1,0 +1,19 @@
+require "dry/web/settings"
+
+module Dry
+  module Web
+    class Umbrella < Dry::Web::Container
+      setting :settings
+
+      def self.configure(env = config.env, &block)
+        super() do |config|
+          yield(config) if block
+
+          config.settings = Settings.load(root, env) unless config.settings
+        end
+
+        self
+      end
+    end
+  end
+end

--- a/lib/dry/web/umbrella.rb
+++ b/lib/dry/web/umbrella.rb
@@ -11,12 +11,23 @@ module Dry
           yield(config) if block
 
           if config.settings_loader && config.settings.kind_of?(EmptySettings)
-            config.settings = config.settings_loader.load(root, env)
+            config.settings = load_settings(config.settings_loader, root, env)
           end
         end
 
         self
       end
+
+      def self.load_settings(loader, root, env)
+        begin
+          loader.load(root, env)
+        rescue => e
+          puts "Could not load your settings: #{e}"
+          puts
+          raise e
+        end
+      end
+      private_class_method :load_settings
     end
   end
 end

--- a/spec/fixtures/test/config/settings.yml
+++ b/spec/fixtures/test/config/settings.yml
@@ -1,0 +1,4 @@
+test:
+  api_key: "yaml123"
+  precompile_assets: "1"
+  undeclared: "not declared in settings"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+ENV["RACK_ENV"] = "test"
+
 if RUBY_ENGINE == "ruby"
   require "codeclimate-test-reporter"
   CodeClimate::TestReporter.start

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Dry::Web::Settings do
         }
 
         it "raises helpful exceptions if input data does not match constraints" do
-          expect { settings }.to raise_error(Dry::Web::Settings::TypeError)
+          expect { settings }.to raise_error(Dry::Web::Settings::SettingValueError)
           expect { settings }.to raise_error(/error typecasting \+api_key\+/)
         end
       end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -70,8 +70,9 @@ RSpec.describe Dry::Web::Settings do
           end.load(SPEC_ROOT.join("fixtures/test"), :test)
         }
 
-        it "supports raising of errors if input data does not match constraints" do
-          expect { settings }.to raise_error(Test::ConstraintNotMatched)
+        it "raises helpful exceptions if input data does not match constraints" do
+          expect { settings }.to raise_error(Dry::Web::Settings::TypeError)
+          expect { settings }.to raise_error(/error typecasting \+api_key\+/)
         end
       end
     end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1,0 +1,79 @@
+require "dry/web/settings"
+
+RSpec.describe Dry::Web::Settings do
+  describe ".setting" do
+    it "raises an error if a duplicate setting is specified" do
+      expect {
+        Class.new(Dry::Web::Settings) do
+          setting :foo
+          setting :foo
+        end
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe ".load" do
+    subject(:settings) {
+      Class.new(Dry::Web::Settings) do
+        setting :api_key
+        setting :precompile_assets
+        setting :env_only_setting
+      end.load(SPEC_ROOT.join("fixtures/test"), :test)
+    }
+
+    it "loads settings from ENV first (as upper-cased variables)" do
+      ENV["ENV_ONLY_SETTING"] = "hello"
+      expect(settings.env_only_setting).to eq "hello"
+    end
+
+    it "loads settings from a YAML file (as lower-cased keys) if unavailable from ENV" do
+      expect(settings.api_key).to eq "yaml123"
+    end
+
+    it "ignores undeclared settings in the YAML file" do
+      expect(settings).not_to respond_to(:undeclared)
+    end
+
+    context "settings with types" do
+      before do
+        Test::CoercingBool = Class.new do
+          def self.[](val)
+            %w[1 true].include?(val.to_s)
+          end
+        end
+
+        Test::ConstraintNotMatched = Class.new(ArgumentError)
+
+        Test::LongString = Class.new do
+          def self.[](val)
+            raise Test::ConstraintNotMatched, "string must be 12 characters or longer" if val.length < 12
+          end
+        end
+      end
+
+      context "coercing types" do
+        subject(:settings) {
+          Class.new(Dry::Web::Settings) do
+            setting :precompile_assets, Test::CoercingBool
+          end.load(SPEC_ROOT.join("fixtures/test"), :test)
+        }
+
+        it "supports coercion input data" do
+          expect(settings.precompile_assets).to eq true
+        end
+      end
+
+      context "constraining types" do
+        subject(:settings) {
+          Class.new(Dry::Web::Settings) do
+            setting :api_key, Test::LongString
+          end.load(SPEC_ROOT.join("fixtures/test"), :test)
+        }
+
+        it "supports raising of errors if input data does not match constraints" do
+          expect { settings }.to raise_error(Test::ConstraintNotMatched)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/umbrella_spec.rb
+++ b/spec/unit/umbrella_spec.rb
@@ -1,0 +1,56 @@
+require "dry/web/settings"
+require "dry/web/umbrella"
+
+RSpec.describe Dry::Web::Umbrella do
+  subject(:umbrella) {
+    Class.new(Dry::Web::Umbrella) do
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures/test")
+      end
+    end
+  }
+
+  describe "config" do
+    describe "#settings" do
+      subject(:settings) { umbrella.config.settings }
+
+      context "no settings specified" do
+        it "is an empty object" do
+          expect(:settings).not_to be_nil
+        end
+
+        it "does not offer any settings" do
+          expect(:settings).not_to respond_to(:some_setting)
+        end
+      end
+
+      context "settings loader specified" do
+        let(:settings_loader) { class_double("Dry::Web::Settings") }
+
+        it "loads the settings using the specified settings_loader" do
+          allow(settings_loader).to receive(:load).with(umbrella.config.root, :test) {
+            double("settings", foo: "bar")
+          }
+
+          umbrella.configure do |config|
+            config.settings_loader = settings_loader
+          end
+
+          expect(settings.foo).to eq "bar"
+        end
+      end
+
+      context "settings object specified" do
+        before do
+          umbrella.configure do |config|
+            config.settings = double("custom settings", bar: "baz")
+          end
+        end
+
+        it "leaves the settings object in place" do
+          expect(settings.bar).to eq "baz"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a much simplified take on app settings compared to https://github.com/dry-rb/dry-web/pull/25, and I like it a lot more.

It automatically loads the settings onto the umbrella container, which I like, and it applies some sensible defaults while still allowing the developer to replace the whole settings object with something of their own choosing, if they want.

It also will nicely support integration with dry-types for people who want to make their settings stricter (or coerce stuff coming in from the ENV into richer Ruby types).

This is feeling like a decent path for us to include in the near term.



